### PR TITLE
Fighter II checkbox

### DIFF
--- a/frontend/src/BudgetModeDisplay.tsx
+++ b/frontend/src/BudgetModeDisplay.tsx
@@ -30,7 +30,7 @@ export function BudgetModeDisplay({
     maxShipCapacity,
     spaceDockFighterBonus,
 }: Props) {
-    const shipCapacityRemaining =
+    const fighterCapacityRemaining =
         maxShipCapacity +
         spaceDockFighterBonus -
         shipCapacityUsed -
@@ -51,14 +51,16 @@ export function BudgetModeDisplay({
                 currentFleetSupply,
                 maxFleetSupply,
                 unitCounts,
-                isFighterUpgraded ? Math.max(0 - shipCapacityRemaining, 0) : 0
+                isFighterUpgraded
+                    ? Math.max(0 - fighterCapacityRemaining, 0)
+                    : 0
             ),
         },
         {
-            label: "Ship Capacity Remaining",
+            label: "Fighter Capacity Remaining",
             value: isFighterUpgraded
-                ? Math.max(shipCapacityRemaining, 0)
-                : shipCapacityRemaining,
+                ? Math.max(fighterCapacityRemaining, 0)
+                : fighterCapacityRemaining,
         },
     ].map(DisplayField);
 }

--- a/frontend/src/BudgetModeDisplay.tsx
+++ b/frontend/src/BudgetModeDisplay.tsx
@@ -1,4 +1,5 @@
 import {
+    getFighterCount,
     getFleetSupplyRemaining,
     getTotalCapacity,
     getTotalCost,
@@ -12,6 +13,10 @@ interface Props {
     currentFleetSupply: number;
     maxFleetSupply: number;
     unitCounts: UnitCounts;
+    isFighterUpgraded: boolean;
+    shipCapacityUsed: number;
+    maxShipCapacity: number;
+    spaceDockFighterBonus: number;
 }
 
 export function BudgetModeDisplay({
@@ -20,14 +25,24 @@ export function BudgetModeDisplay({
     currentFleetSupply,
     maxFleetSupply,
     unitCounts,
+    isFighterUpgraded,
+    shipCapacityUsed,
+    maxShipCapacity,
+    spaceDockFighterBonus,
 }: Props) {
+    const shipCapacityRemaining =
+        maxShipCapacity +
+        spaceDockFighterBonus -
+        shipCapacityUsed -
+        getFighterCount(unitCounts);
+
     return [
         {
             label: "Resources Remaining",
             value: resourceBudget - getTotalCost(unitCounts),
         },
         {
-            label: "Capacity Remaining",
+            label: "Production Capacity Remaining",
             value: capacityBudget - getTotalCapacity(unitCounts),
         },
         {
@@ -35,8 +50,15 @@ export function BudgetModeDisplay({
             value: getFleetSupplyRemaining(
                 currentFleetSupply,
                 maxFleetSupply,
-                unitCounts
+                unitCounts,
+                isFighterUpgraded ? Math.max(0 - shipCapacityRemaining, 0) : 0
             ),
+        },
+        {
+            label: "Ship Capacity Remaining",
+            value: isFighterUpgraded
+                ? Math.max(shipCapacityRemaining, 0)
+                : shipCapacityRemaining,
         },
     ].map(DisplayField);
 }

--- a/frontend/src/BudgetModeDisplay.tsx
+++ b/frontend/src/BudgetModeDisplay.tsx
@@ -1,8 +1,8 @@
 import {
     getFighterCount,
     getFleetSupplyRemaining,
-    getTotalCapacity,
     getTotalCost,
+    sumUnitCounts,
     UnitCounts,
 } from "./data";
 import { DisplayField } from "./DisplayField";
@@ -43,7 +43,7 @@ export function BudgetModeDisplay({
         },
         {
             label: "Production Capacity Remaining",
-            value: capacityBudget - getTotalCapacity(unitCounts),
+            value: capacityBudget - sumUnitCounts(unitCounts),
         },
         {
             label: "Fleet Supply Remaining",

--- a/frontend/src/BudgetModeDisplay.tsx
+++ b/frontend/src/BudgetModeDisplay.tsx
@@ -58,9 +58,10 @@ export function BudgetModeDisplay({
         },
         {
             label: "Fighter Capacity Remaining",
-            value: isFighterUpgraded
-                ? Math.max(fighterCapacityRemaining, 0)
-                : fighterCapacityRemaining,
+            value:
+                isFighterUpgraded && fighterCapacityRemaining < 0
+                    ? 0
+                    : fighterCapacityRemaining,
         },
     ].map(DisplayField);
 }

--- a/frontend/src/BudgetModeDisplay.tsx
+++ b/frontend/src/BudgetModeDisplay.tsx
@@ -36,6 +36,11 @@ export function BudgetModeDisplay({
         shipCapacityUsed -
         getFighterCount(unitCounts);
 
+    const unsupportedFighters =
+        isFighterUpgraded && fighterCapacityRemaining < 0
+            ? Math.abs(fighterCapacityRemaining)
+            : 0;
+
     return [
         {
             label: "Resources Remaining",
@@ -51,17 +56,12 @@ export function BudgetModeDisplay({
                 currentFleetSupply,
                 maxFleetSupply,
                 unitCounts,
-                isFighterUpgraded && fighterCapacityRemaining < 0
-                    ? Math.abs(fighterCapacityRemaining)
-                    : 0
+                unsupportedFighters
             ),
         },
         {
             label: "Fighter Capacity Remaining",
-            value:
-                isFighterUpgraded && fighterCapacityRemaining < 0
-                    ? 0
-                    : fighterCapacityRemaining,
+            value: unsupportedFighters ? 0 : fighterCapacityRemaining,
         },
     ].map(DisplayField);
 }

--- a/frontend/src/BudgetModeDisplay.tsx
+++ b/frontend/src/BudgetModeDisplay.tsx
@@ -51,8 +51,8 @@ export function BudgetModeDisplay({
                 currentFleetSupply,
                 maxFleetSupply,
                 unitCounts,
-                isFighterUpgraded
-                    ? Math.max(0 - fighterCapacityRemaining, 0)
+                isFighterUpgraded && fighterCapacityRemaining < 0
+                    ? Math.abs(fighterCapacityRemaining)
                     : 0
             ),
         },

--- a/frontend/src/BudgetModeInputs.tsx
+++ b/frontend/src/BudgetModeInputs.tsx
@@ -10,6 +10,12 @@ interface Props {
     setCurrentFleetSupply: (value: number) => void;
     maxFleetSupply: number;
     setMaxFleetSupply: (value: number) => void;
+    shipCapacityUsed: number;
+    setShipCapacityUsed: (value: number) => void;
+    maxShipCapacity: number;
+    setMaxShipCapacity: (value: number) => void;
+    spaceDockFighterBonus: number;
+    setSpaceDockFighterBonus: (value: number) => void;
 }
 
 export function BudgetModeInputs({
@@ -21,6 +27,12 @@ export function BudgetModeInputs({
     setCurrentFleetSupply,
     maxFleetSupply,
     setMaxFleetSupply,
+    shipCapacityUsed,
+    setShipCapacityUsed,
+    maxShipCapacity,
+    setMaxShipCapacity,
+    spaceDockFighterBonus,
+    setSpaceDockFighterBonus,
 }: Props) {
     return (
         <>
@@ -43,6 +55,21 @@ export function BudgetModeInputs({
                 label="Max Fleet Supply"
                 value={maxFleetSupply}
                 onChange={setMaxFleetSupply}
+            />
+            <BudgetInput
+                label="Ship Capacity Used"
+                value={shipCapacityUsed}
+                onChange={setShipCapacityUsed}
+            />
+            <BudgetInput
+                label="Max Ship Capacity"
+                value={maxShipCapacity}
+                onChange={setMaxShipCapacity}
+            />
+            <BudgetInput
+                label="Space Dock Fighter Bonus"
+                value={spaceDockFighterBonus}
+                onChange={setSpaceDockFighterBonus}
             />
         </>
     );

--- a/frontend/src/BudgetModeInputs.tsx
+++ b/frontend/src/BudgetModeInputs.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import Checkbox from "@mui/joy/Checkbox";
 import { BudgetInput } from "./BudgetInput";
 
 interface Props {
@@ -10,6 +11,8 @@ interface Props {
     setCurrentFleetSupply: (value: number) => void;
     maxFleetSupply: number;
     setMaxFleetSupply: (value: number) => void;
+    isFighterUpgraded: boolean;
+    setIsFighterUpgraded: (value: boolean) => void;
     shipCapacityUsed: number;
     setShipCapacityUsed: (value: number) => void;
     maxShipCapacity: number;
@@ -27,6 +30,8 @@ export function BudgetModeInputs({
     setCurrentFleetSupply,
     maxFleetSupply,
     setMaxFleetSupply,
+    isFighterUpgraded,
+    setIsFighterUpgraded,
     shipCapacityUsed,
     setShipCapacityUsed,
     maxShipCapacity,
@@ -70,6 +75,11 @@ export function BudgetModeInputs({
                 label="Space Dock Fighter Bonus"
                 value={spaceDockFighterBonus}
                 onChange={setSpaceDockFighterBonus}
+            />
+            <Checkbox
+                label="Fighter II"
+                checked={isFighterUpgraded}
+                onChange={() => setIsFighterUpgraded(!isFighterUpgraded)}
             />
         </>
     );

--- a/frontend/src/Calculator.tsx
+++ b/frontend/src/Calculator.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
 import { useState } from "react";
 import Box from "@mui/joy/Box";
-import Checkbox from "@mui/joy/Checkbox";
 import { ModeToggle } from "./ModeToggle";
 import { Unit, Mode, getUnitCost, getImgPath, UnitCounts } from "./data";
 import { UnitCounter } from "./UnitCounter";
@@ -69,19 +68,14 @@ export default function ProductionHelper() {
                             setCurrentFleetSupply={setCurrentFleetSupply}
                             maxFleetSupply={maxFleetSupply}
                             setMaxFleetSupply={setMaxFleetSupply}
+                            isFighterUpgraded={isFighterUpgraded}
+                            setIsFighterUpgraded={setIsFighterUpgraded}
                             shipCapacityUsed={shipCapacityUsed}
                             setShipCapacityUsed={setShipCapacityUsed}
                             maxShipCapacity={maxShipCapacity}
                             setMaxShipCapacity={setMaxShipCapacity}
                             spaceDockFighterBonus={spaceDockFighterBonus}
                             setSpaceDockFighterBonus={setSpaceDockFighterBonus}
-                        />
-                        <Checkbox
-                            label="Fighter II"
-                            checked={isFighterUpgraded}
-                            onChange={() =>
-                                setIsFighterUpgraded(!isFighterUpgraded)
-                            }
                         />
                     </Box>
                 );

--- a/frontend/src/Calculator.tsx
+++ b/frontend/src/Calculator.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { useState } from "react";
 import Box from "@mui/joy/Box";
+import Checkbox from "@mui/joy/Checkbox";
 import { ModeToggle } from "./ModeToggle";
 import { Unit, Mode, getUnitCost, getImgPath, UnitCounts } from "./data";
 import { UnitCounter } from "./UnitCounter";
@@ -17,6 +18,10 @@ export default function ProductionHelper() {
     const [capacityBudget, setCapacityBudget] = useState(0);
     const [currentFleetSupply, setCurrentFleetSupply] = useState(0);
     const [maxFleetSupply, setMaxFleetSupply] = useState(0);
+    const [isFighterUpgraded, setIsFighterUpgraded] = useState(false);
+    const [shipCapacityUsed, setShipCapacityUsed] = useState(0);
+    const [maxShipCapacity, setMaxShipCapacity] = useState(0);
+    const [spaceDockFighterBonus, setSpaceDockFighterBonus] = useState(0);
 
     function handleModeChange() {
         switch (mode) {
@@ -50,6 +55,10 @@ export default function ProductionHelper() {
                             currentFleetSupply={currentFleetSupply}
                             maxFleetSupply={maxFleetSupply}
                             unitCounts={unitCounts}
+                            isFighterUpgraded={isFighterUpgraded}
+                            shipCapacityUsed={shipCapacityUsed}
+                            maxShipCapacity={maxShipCapacity}
+                            spaceDockFighterBonus={spaceDockFighterBonus}
                         />
                         <BudgetModeInputs
                             resourceBudget={resourceBudget}
@@ -60,6 +69,19 @@ export default function ProductionHelper() {
                             setCurrentFleetSupply={setCurrentFleetSupply}
                             maxFleetSupply={maxFleetSupply}
                             setMaxFleetSupply={setMaxFleetSupply}
+                            shipCapacityUsed={shipCapacityUsed}
+                            setShipCapacityUsed={setShipCapacityUsed}
+                            maxShipCapacity={maxShipCapacity}
+                            setMaxShipCapacity={setMaxShipCapacity}
+                            spaceDockFighterBonus={spaceDockFighterBonus}
+                            setSpaceDockFighterBonus={setSpaceDockFighterBonus}
+                        />
+                        <Checkbox
+                            label="Fighter II"
+                            checked={isFighterUpgraded}
+                            onChange={() =>
+                                setIsFighterUpgraded(!isFighterUpgraded)
+                            }
                         />
                     </Box>
                 );

--- a/frontend/src/CalculatorModeDisplay.tsx
+++ b/frontend/src/CalculatorModeDisplay.tsx
@@ -1,4 +1,4 @@
-import { getTotalCapacity, getTotalCost, UnitCounts } from "./data";
+import { getTotalCost, sumUnitCounts, UnitCounts } from "./data";
 import { DisplayField } from "./DisplayField";
 
 interface Props {
@@ -13,7 +13,7 @@ export function CalculatorModeDisplay({ unitCounts }: Props) {
         },
         {
             label: "Total Capacity",
-            value: getTotalCapacity(unitCounts),
+            value: sumUnitCounts(unitCounts),
         },
     ].map(DisplayField);
 }

--- a/frontend/src/data.ts
+++ b/frontend/src/data.ts
@@ -87,20 +87,36 @@ export function getTotalCost(unitCounts: UnitCounts): number {
     );
 }
 
+function sumUnitCountEntries(unitCountEntries: [Unit, number][]): number {
+    return unitCountEntries.reduce((sum, [, count]) => sum + count, 0);
+}
+
 export function getTotalCapacity(unitCounts: UnitCounts): number {
-    return Array.from(unitCounts).reduce((acc, [, b]) => acc + b, 0);
+    return sumUnitCountEntries(Array.from(unitCounts));
+}
+
+export function getFighterCount(unitCounts: UnitCounts): number {
+    return sumUnitCountEntries(
+        Array.from(unitCounts).filter(([unit]) => unit === Unit.FIGHTER)
+    );
 }
 
 export function getFleetSupplyRemaining(
     currentFleetSupply: number,
     maxFleetSupply: number,
-    unitCounts: UnitCounts
+    unitCounts: UnitCounts,
+    airborneFighterCount: number
 ) {
-    return Array.from(unitCounts).reduce(
-        (acc, [a, b]) =>
-            a === Unit.INFANTRY || a === Unit.FIGHTER || a === Unit.MECH
-                ? acc
-                : acc - b,
-        maxFleetSupply - currentFleetSupply
+    const shipCount = sumUnitCountEntries(
+        Array.from(unitCounts).filter(
+            ([unit]) =>
+                unit !== Unit.INFANTRY &&
+                unit !== Unit.FIGHTER &&
+                unit !== Unit.MECH
+        )
+    );
+
+    return (
+        maxFleetSupply - currentFleetSupply - shipCount - airborneFighterCount
     );
 }

--- a/frontend/src/data.ts
+++ b/frontend/src/data.ts
@@ -104,7 +104,7 @@ export function getFleetSupplyRemaining(
     currentFleetSupply: number,
     maxFleetSupply: number,
     unitCounts: UnitCounts,
-    airborneFighterCount: number
+    unsupportedFighters: number
 ) {
     const shipCount = sumUnitCounts(
         unitCounts,
@@ -115,6 +115,6 @@ export function getFleetSupplyRemaining(
     );
 
     return (
-        maxFleetSupply - currentFleetSupply - shipCount - airborneFighterCount
+        maxFleetSupply - currentFleetSupply - shipCount - unsupportedFighters
     );
 }

--- a/frontend/src/data.ts
+++ b/frontend/src/data.ts
@@ -87,18 +87,17 @@ export function getTotalCost(unitCounts: UnitCounts): number {
     );
 }
 
-function sumUnitCountEntries(unitCountEntries: [Unit, number][]): number {
-    return unitCountEntries.reduce((sum, [, count]) => sum + count, 0);
-}
-
-export function getTotalCapacity(unitCounts: UnitCounts): number {
-    return sumUnitCountEntries(Array.from(unitCounts));
+export function sumUnitCounts(
+    unitCounts: UnitCounts,
+    unitFilter: (unit: Unit) => boolean = () => true
+): number {
+    return Array.from(unitCounts)
+        .filter(([unit]) => unitFilter(unit))
+        .reduce((sum, [, count]) => sum + count, 0);
 }
 
 export function getFighterCount(unitCounts: UnitCounts): number {
-    return sumUnitCountEntries(
-        Array.from(unitCounts).filter(([unit]) => unit === Unit.FIGHTER)
-    );
+    return sumUnitCounts(unitCounts, (unit) => unit === Unit.FIGHTER);
 }
 
 export function getFleetSupplyRemaining(
@@ -107,13 +106,12 @@ export function getFleetSupplyRemaining(
     unitCounts: UnitCounts,
     airborneFighterCount: number
 ) {
-    const shipCount = sumUnitCountEntries(
-        Array.from(unitCounts).filter(
-            ([unit]) =>
-                unit !== Unit.INFANTRY &&
-                unit !== Unit.FIGHTER &&
-                unit !== Unit.MECH
-        )
+    const shipCount = sumUnitCounts(
+        unitCounts,
+        (unit) =>
+            unit !== Unit.INFANTRY &&
+            unit !== Unit.FIGHTER &&
+            unit !== Unit.MECH
     );
 
     return (


### PR DESCRIPTION
Took a stab at this, check my logic though!

### New budget inputs:
- `shipCapacityUsed`
- `maxShipCapacity`
- `spaceDockFighterBonus`

### New budget display field:
- `shipCapacityRemaining`: `maxShipCapacity` + `spaceDockFighterBonus` - `shipCapacityUsed` - fighters added with the calculator
  - **Fighter I:** All fighters count against `shipCapacityRemaining`
  - **Fighter II:** Fighters count against `shipCapacityRemaining` until it reaches 0, then they begin to count against `fleetSupplyRemaining`

I realized there should also be a checkbox for "I'm building in a space-only system" for Saar (maybe others?), which would trigger ground forces to be subtracted from `shipCapacityRemaining`, but leaving that for another PR!