### PR TITLE
Label sidebar menu button and add minimal styling

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -48,10 +48,13 @@ function DrawerNavigation() {
     return (
         <>
             <IconButton
-                variant="solid"
+                variant="outlined"
                 color="primary"
                 onClick={() => setOpen(true)}
-            />
+                sx={{ mb: 2, p: 1 }}
+            >
+                Menu
+            </IconButton>
             <Drawer open={open} onClose={() => setOpen(false)}>
                 <List
                     size="lg"


### PR DESCRIPTION
I tried installing MUI icons and using a hamburger icon, but it only allowed this style of import, which would unnecessarily inflate the bundle size (I think?):
```
import { Menu } from "@mui/icons-material";
```
whereas I wanted to use:
```
import Menu from "@mui/icons-material/Menu";
```
The docs say it should allow both import types, so I think the problem may be: https://github.com/mui/material-ui/issues/35535

I haven't gone deeper on it yet, but just adding this change in the meantime so it's not a blank button!