### PR TITLE
Improve UI of budget inputs

### DIFF
--- a/frontend/src/BudgetCard.tsx
+++ b/frontend/src/BudgetCard.tsx
@@ -64,6 +64,7 @@ export function BudgetCard({ unitCounts, budgetFilters }: Props) {
             <HeaderLabel text="Resources" />,
             <BudgetInput
                 label="Resource Budget"
+                placeholder="$"
                 value={resourceBudget}
                 onChange={setResourceBudget}
             />,
@@ -79,6 +80,7 @@ export function BudgetCard({ unitCounts, budgetFilters }: Props) {
             <HeaderLabel text="Production Limit" />,
             <BudgetInput
                 label="Production Limit Budget"
+                placeholder="units"
                 value={capacityBudget}
                 onChange={setCapacityBudget}
             />,
@@ -94,11 +96,13 @@ export function BudgetCard({ unitCounts, budgetFilters }: Props) {
             <HeaderLabel text="Fleet Supply" />,
             <BudgetInput
                 label="Fleet Supply Budget"
+                placeholder="ships"
                 value={maxFleetSupply}
                 onChange={setMaxFleetSupply}
             />,
             <BudgetInput
                 label="Fleet Supply In Use"
+                placeholder="ships"
                 value={currentFleetSupply}
                 onChange={setCurrentFleetSupply}
             />,
@@ -118,11 +122,13 @@ export function BudgetCard({ unitCounts, budgetFilters }: Props) {
             <HeaderLabel text="Fighter Capacity" />,
             <BudgetInput
                 label="Fighter Capacity Budget"
+                placeholder="units"
                 value={maxShipCapacity}
                 onChange={setMaxShipCapacity}
             />,
             <BudgetInput
                 label="Fighter Capacity In Use"
+                placeholder="units"
                 value={shipCapacityUsed}
                 onChange={setShipCapacityUsed}
             />,
@@ -153,6 +159,7 @@ export function BudgetCard({ unitCounts, budgetFilters }: Props) {
                             />,
                             <BudgetInput
                                 label="Space Dock Fighter Bonus"
+                                placeholder="units"
                                 isLabelVisible
                                 value={spaceDockFighterBonus}
                                 onChange={setSpaceDockFighterBonus}

--- a/frontend/src/BudgetInput.tsx
+++ b/frontend/src/BudgetInput.tsx
@@ -2,11 +2,13 @@ import * as React from "react";
 import Input from "@mui/joy/Input";
 import Typography from "@mui/joy/Typography";
 import Stack from "@mui/joy/Stack";
+import { DecoratorStepper } from "./DecoratorStepper";
 
 interface Props {
     label: string;
     isLabelVisible?: boolean;
     value: number;
+    placeholder?: string;
     onChange: (value: number) => void;
 }
 
@@ -14,18 +16,46 @@ export function BudgetInput({
     label,
     isLabelVisible = false,
     value,
+    placeholder = "",
     onChange,
 }: Props) {
+    const min = 0;
+    const max = 999;
+
     return (
         <Stack spacing={1} maxWidth="100%">
             {isLabelVisible && <Typography level="body-xs">{label}</Typography>}
             <Input
                 aria-label={label}
                 size="sm"
-                type="number"
-                value={value}
-                onChange={(event) => onChange(Number(event.target.value))}
+                sx={{ backgroundColor: "white" }}
+                placeholder={placeholder}
+                value={value || ""}
+                onChange={(event) => {
+                    const numValue = Number(event.target.value);
+
+                    if (
+                        isNumber(numValue) &&
+                        numValue >= min &&
+                        numValue <= max
+                    ) {
+                        onChange(numValue);
+                    }
+                }}
+                endDecorator={
+                    <DecoratorStepper
+                        value={value}
+                        min={min}
+                        max={max}
+                        step={1}
+                        onChange={onChange}
+                    />
+                }
             />
         </Stack>
     );
+}
+
+function isNumber(value: unknown) {
+    return typeof value === "number";
 }

--- a/frontend/src/DecoratorStepper.tsx
+++ b/frontend/src/DecoratorStepper.tsx
@@ -1,0 +1,47 @@
+import * as React from "react";
+import { Button } from "@mui/base/Button";
+import Divider from "@mui/joy/Divider";
+import Stack from "@mui/joy/Stack";
+import { MinusIcon, PlusIcon } from "./Icons";
+
+interface Props {
+    value: number;
+    min: number;
+    max: number;
+    step: number;
+    onChange: (value: number) => void;
+}
+
+export function DecoratorStepper({ value, min, max, step, onChange }: Props) {
+    const buttonStyle: React.CSSProperties = {
+        position: "relative",
+        display: "flex",
+        justifyContent: "center",
+        alignItems: "center",
+        width: "17px",
+        height: "17px",
+        cursor: "pointer",
+        backgroundColor: "white",
+        border: "none",
+    };
+
+    return (
+        <Stack>
+            <Button
+                style={buttonStyle}
+                onClick={() => onChange(Math.min(value + step, max))}
+                aria-label="increment"
+            >
+                <PlusIcon />
+            </Button>
+            <Divider />
+            <Button
+                style={buttonStyle}
+                onClick={() => onChange(Math.max(value - step, min))}
+                aria-label="decrement"
+            >
+                <MinusIcon />
+            </Button>
+        </Stack>
+    );
+}

--- a/frontend/src/Icons.tsx
+++ b/frontend/src/Icons.tsx
@@ -1,0 +1,40 @@
+import * as React from "react";
+import Box from "@mui/joy/Box";
+
+export function PlusIcon() {
+    return (
+        <Box
+            position="absolute"
+            width="40%"
+            height="40%"
+            display="flex"
+            alignItems="center"
+            justifyContent="center"
+        >
+            <Box
+                position="absolute"
+                height={0}
+                width="100%"
+                borderTop={"2px solid #888"}
+            />
+            <Box
+                position="absolute"
+                height="100%"
+                width={0}
+                borderLeft={"2px solid #888"}
+            />
+        </Box>
+    );
+}
+
+export function MinusIcon() {
+    return (
+        <Box
+            position="absolute"
+            boxSizing="border-box"
+            height={0}
+            width="40%"
+            borderTop={"2px solid #888"}
+        />
+    );
+}

--- a/frontend/src/InputStepper.tsx
+++ b/frontend/src/InputStepper.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import Box from "@mui/joy/Box";
 import IconButton from "@mui/joy/IconButton";
 import Typography from "@mui/joy/Typography";
+import { MinusIcon, PlusIcon } from "./Icons";
 
 interface Props {
     value: number;
@@ -48,44 +49,6 @@ export function InputStepper({ value, min, max, step, onChange }: Props) {
             >
                 <PlusIcon />
             </IconButton>
-        </Box>
-    );
-}
-
-function MinusIcon() {
-    return (
-        <Box
-            position="absolute"
-            boxSizing="border-box"
-            height={0}
-            width="40%"
-            borderTop={"2px solid #888"}
-        />
-    );
-}
-
-function PlusIcon() {
-    return (
-        <Box
-            position="absolute"
-            width="40%"
-            height="40%"
-            display="flex"
-            alignItems="center"
-            justifyContent="center"
-        >
-            <Box
-                position="absolute"
-                height={0}
-                width="100%"
-                borderTop={"2px solid #888"}
-            />
-            <Box
-                position="absolute"
-                height="100%"
-                width={0}
-                borderLeft={"2px solid #888"}
-            />
         </Box>
     );
 }


### PR DESCRIPTION
- Discard `type="number"` because it makes the input buggy as hell - instead, manually allow only a number between 0 and 999 in the `onChange`

- Add placeholder text

- Make background white so it pops more

- Add a mini stepper to improve UX on a phone

- Mask value of `0` with an empty string to prevent leading 0s. Ended up not getting into a `.touched` analysis - UX isn't as bad as I feared:
  - Typing a single zero appears to do nothing - fine
  - Using the stepper to decrement from `1` appears to empty the input - fine
  - Typing `100` and then deleting the leading `1` is the oddest - this also empties the input. I'm okay with it though

| | |
|-|-|
| <img width="600" alt="image" src="https://github.com/user-attachments/assets/164c4a68-9378-40e6-a0d7-3dab7f39fffc"> | <img width="622" alt="image" src="https://github.com/user-attachments/assets/dffb22ce-bd1b-426e-a26e-f673a6015ea4"> |
