### PR TITLE
Relabel "Total Capacity" to "Total Units" in Calculator mode

### DIFF
--- a/frontend/src/CalculatorModeDisplay.tsx
+++ b/frontend/src/CalculatorModeDisplay.tsx
@@ -12,7 +12,7 @@ export function CalculatorModeDisplay({ unitCounts }: Props) {
             value: getTotalCost(unitCounts),
         },
         {
-            label: "Total Capacity",
+            label: "Total Units",
             value: sumUnitCounts(unitCounts),
         },
     ].map(DisplayField);


### PR DESCRIPTION
"Capacity" reads like "how much I have left" when really we want "capacity consumed" - AKA "units" for brevity!

<img width="324" alt="image" src="https://github.com/user-attachments/assets/17239145-efbf-4873-b41d-37c5437622ba">
