### PR TITLE
Disable zoom on double tap

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -37,7 +37,7 @@ export default function App() {
 
 function Home() {
     return (
-        <Box p="10px">
+        <Box p="10px" sx={{ touchAction: "manipulation" }}>
             <ProductionHelper />
         </Box>
     );


### PR DESCRIPTION
Was trying out the new input fields on my phone and it's very annoying when I press the +/- buttons too fast and it zooms!