### PR TITLE
Default to number keyboard for budget input fields

### DIFF
--- a/frontend/src/BudgetInput.tsx
+++ b/frontend/src/BudgetInput.tsx
@@ -31,6 +31,11 @@ export function BudgetInput({
                 sx={{ backgroundColor: "white" }}
                 placeholder={placeholder}
                 value={value || ""}
+                slotProps={{
+                    input: {
+                        inputMode: "numeric",
+                    },
+                }}
                 onChange={(event) => {
                     const numValue = Number(event.target.value);
 


### PR DESCRIPTION
I don't have an easy way of testing this without deploying it, but it's my best guess. Hoping this will work without changing `type` back to `number` 🤞 