### PR TITLE
Set input font size to 16px on focus (prevents mobile auto-zoom)

### DIFF
--- a/frontend/src/BudgetInput.tsx
+++ b/frontend/src/BudgetInput.tsx
@@ -28,7 +28,10 @@ export function BudgetInput({
             <Input
                 aria-label={label}
                 size="sm"
-                sx={{ backgroundColor: "white" }}
+                sx={{
+                    backgroundColor: "white",
+                    "&:focus-within": { fontSize: "16px" },
+                }}
                 placeholder={placeholder}
                 value={value || ""}
                 slotProps={{


### PR DESCRIPTION
Another thing that was bothering me, it's so disruptive when it zooms anytime I type 🥴 

Apparently it's some sort of mobile browser standard for auto-zoom to occur when the font size of an input is < 16px. I couldn't find a non-controversial way to shut this off, and we don't have much real estate on a phone to increase the font size, so my middle ground was to increase the font size on focus (which is not unlike zooming I guess, but less intrusive).

I deployed this branch so I could test it, so the change is out there if you want to look!