### PR TITLE
Redirect http to https

### DIFF
--- a/infrastructure/lib/infrastructure-stack.ts
+++ b/infrastructure/lib/infrastructure-stack.ts
@@ -50,6 +50,8 @@ export class InfrastructureStack extends cdk.Stack {
                             cloudfront.LambdaEdgeEventType.VIEWER_REQUEST,
                     },
                 ],
+                viewerProtocolPolicy:
+                    cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
             },
             certificate: certificate,
             domainNames: [


### PR DESCRIPTION
Resolves #28 

Tested by deploying (so this is already live). Try hitting http://twilightimperiumtools.bradleysherman.net to see. You may need to clear your browser cache for the site first.