### PR TITLE
Add hamburger icon

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
             "dependencies": {
                 "@emotion/react": "^11.13.0",
                 "@emotion/styled": "^11.13.0",
+                "@mui/icons-material": "^5.16.7",
                 "@mui/joy": "^5.0.0-beta.36",
                 "@mui/material": "^5.16.5",
                 "react": "^18.3.1",
@@ -1817,6 +1818,32 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/mui-org"
+            }
+        },
+        "node_modules/@mui/icons-material": {
+            "version": "5.16.7",
+            "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.16.7.tgz",
+            "integrity": "sha512-UrGwDJCXEszbDI7yV047BYU5A28eGJ79keTCP4cc74WyncuVrnurlmIRxaHL8YK+LI1Kzq+/JM52IAkNnv4u+Q==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.23.9"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/mui-org"
+            },
+            "peerDependencies": {
+                "@mui/material": "^5.0.0",
+                "@types/react": "^17.0.0 || ^18.0.0",
+                "react": "^17.0.0 || ^18.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@mui/joy": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,6 +33,7 @@
     "dependencies": {
         "@emotion/react": "^11.13.0",
         "@emotion/styled": "^11.13.0",
+        "@mui/icons-material": "^5.16.7",
         "@mui/joy": "^5.0.0-beta.36",
         "@mui/material": "^5.16.5",
         "react": "^18.3.1",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import IconButton from "@mui/joy/IconButton";
 import Drawer from "@mui/joy/Drawer";
 import List from "@mui/joy/List";
 import ListItemButton from "@mui/joy/ListItemButton";
+import { Menu as MenuIcon } from "@mui/icons-material";
 import { BrowserRouter, Routes, Route, Link } from "react-router-dom";
 import ProductionHelper from "./ProductionHelper";
 
@@ -54,7 +55,7 @@ function DrawerNavigation() {
                 onClick={() => setOpen(true)}
                 sx={{ mb: 2, p: 1 }}
             >
-                Menu
+                <MenuIcon />
             </IconButton>
             <Drawer open={open} onClose={() => setOpen(false)}>
                 <List

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -47,4 +47,8 @@ module.exports = {
         }),
         new MiniCssExtractPlugin(),
     ],
+    performance: {
+        maxEntrypointSize: 512000,
+        maxAssetSize: 512000,
+    },
 };


### PR DESCRIPTION
Doesn't get around #14 but it looks like things are pretty gross there, so...

As a small compromise, I adjusted the bundle size warning up to 500 kB. Some metrics:
* Our current bundle is 385 kB
* With this change, that increases to something like 402 kB

Cloudfront compresses the bundle before serving it, so that results in a compressed bundle size of about 120 kB, which I think is perfectly reasonable. As annoying as this issue is, I vote we do it unless/until it poses a measurable problem.