### PR TITLE
Increase "sm" breakpoint to 330px

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,7 +14,7 @@ const theme = extendTheme({
     breakpoints: {
         values: {
             xs: 0,
-            sm: 230,
+            sm: 330,
             md: 900,
             lg: 1200,
             xl: 1536,


### PR DESCRIPTION
Need to break to the `xs` layout (i.e. no unit labels) a bit sooner to account for the TG icons